### PR TITLE
31

### DIFF
--- a/server-bot.js
+++ b/server-bot.js
@@ -4,8 +4,9 @@ const { Telegraf } = require('telegraf')
 const { message } = require('telegraf/filters')
 
 const bot = new Telegraf(process.env.BOT_TOKEN)
+// Зміна використання OpenAI API ключа на новий
 const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
+    apiKey: process.env.NEW_OPENAI_API_KEY, // оновлений ключ
 });
 
 // Функція для надсилання тексту до ChatGPT і отримання результату


### PR DESCRIPTION
This commit updates the OpenAI API key used in the code to `NEW_OPENAI_API_KEY`, which requires users to provide a new API key. This is a breaking change as it may cause the program to malfunction if the new API key is not correctly configured or invalid.