### PR TITLE
20

### DIFF
--- a/server-bot.js
+++ b/server-bot.js
@@ -14,7 +14,7 @@ async function getChatGPTResponse(prompt) {
         const response = await openai.complete({
             engine: 'gpt-3.5-turbo',
             prompt: prompt,
-            maxTokens: 100 // Змініть за потребою
+            maxTokens: 250 // Змініть за потребою
         });
         return response.data.choices[0].text.trim();
     } catch (error) {


### PR DESCRIPTION
This commit introduces a breaking change by increasing the maximum token limit for the `getChatGPTResponse` function to 250. This change is made to improve the response quality, although it may affect performance. Please review the code changes carefully.